### PR TITLE
IOS pass "opts" for "open" function options

### DIFF
--- a/WindowStack.js
+++ b/WindowStack.js
@@ -72,7 +72,7 @@ function WindowStack() {
 	 * @param  {nl.fokkezb.drawer}				drawer			nl.fokkezb.drawer instance
 	 * @return {VOID}
 	 */
-	this.open = function(_window, drawer) {
+	this.open = function(_window, drawer, opts) {
 
 		if (IOS) {
 
@@ -94,7 +94,7 @@ function WindowStack() {
 					// Open the window into the drawer
 					drawer[openIn](navigationWindow);
 				} else {
-					navigationWindow.open();
+					navigationWindow.open(_.extend({}, opts));
 				}
 
 				// Reset our local stack refrance


### PR DESCRIPTION
open the navigation window as model with passed options

windowStack.open($.win, null, {
        modal: true,
        modalTransitionStyle: Ti.UI.iOS.MODAL_TRANSITION_STYLE_CROSS_DISSOLVE,
        modalStyle: Ti.UI.iOS.MODAL_PRESENTATION_FORMSHEET
    });